### PR TITLE
config.yml added weather_forecast_method selection

### DIFF
--- a/emhass/config.yml
+++ b/emhass/config.yml
@@ -42,6 +42,7 @@ options:
   weight_battery_discharge: 1.0
   weight_battery_charge: 1.0
   load_forecast_method: "naive"
+  weather_forecast_method: "scrapper"
   sensor_power_photovoltaics: sensor.power_photovoltaics
   sensor_power_load_no_var_loads: sensor.power_load_no_var_loads
   number_of_deferrable_loads: 2
@@ -104,6 +105,7 @@ schema:
   weight_battery_discharge: float
   weight_battery_charge: float
   load_forecast_method: str
+  weather_forecast_method: list(scrapper|solcast|csv|solar.forecast)
   sensor_power_photovoltaics: str
   sensor_power_load_no_var_loads: str
   number_of_deferrable_loads: int(1,10)

--- a/emhass/translations/en.yaml
+++ b/emhass/translations/en.yaml
@@ -53,6 +53,9 @@ configuration:
   load_forecast_method:
     name: The load forecast method
     description: This defaults to 'naive'. The available options are 'csv', 'list' or 'mlforecaster' to use the machine learning forecaster.
+  weather_forecast_method:
+    name: The weather/production forecast method
+    description: This defaults to 'scrapper'. The available options are 'scrapper', 'csv', 'solcast' or 'solar.forecast'. See (wiki)[https://emhass.readthedocs.io/en/latest/forecasts.html#pv-power-production-forecast] for more information.
   sensor_power_photovoltaics:
     name: The Home Assistant sensor for PV power production
     description: This is the name of the photovoltaic produced power sensor in Watts from Home Assistant. For example sensor.power_photovoltaics.


### PR DESCRIPTION
Added *(to what I believe )* is the options to select `Solcast` and `solar.forecast` as weather options for HA.

copy of https://github.com/davidusb-geek/emhass-add-on/pull/67 *(just changed the branch title)*