### PR TITLE
publish_docker.yaml timeout

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Not tested, and only there for a patch fix for the real issue.