### PR TITLE
Addon configs for config_path and data_path

### DIFF
--- a/emhass-test/config.yml
+++ b/emhass-test/config.yml
@@ -16,6 +16,9 @@ ports_description:
 webui: http://[HOST]:[PORT:5000]
 map:
   - share:rw
+  - type: addon_config
+    path: /config
+    read_only: False
 init: false
 hassio_role: default
 homeassistant_api: true
@@ -27,7 +30,8 @@ panel_title: EMHASS-test
 schema:
   hass_url: "str?" #optional
   long_lived_token: "password?" #optional
-  data_path: "list(default|/data/|/share)?" #optional
+  data_path: "list(default|/config|/data|/share|/share/emhass)?" #optional
+  config_path: "list(default|/config/config.json|/share/config.json|/share/emhass/config.json)?" #optional
   time_zone: "match((\\w+)?(\\/)(\\w+))?" #optional
   Latitude: "float?" #optional
   Longitude: "float?" #optional

--- a/emhass-test/translations/en.yaml
+++ b/emhass-test/translations/en.yaml
@@ -10,7 +10,7 @@ configuration:
     description: long_lived_token (Default "empty").If using the supervisor (this Home Assistant) you can leave this to the default "empty" value.  Otherwise enter the Long-Lived Access Token for your Home Assistant instance, this can be created from the Lovelace profile page.
   data_path:
     name: Set folder path where EMHASS data will be stored
-    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only assessable by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
+    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only accessible by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
   config_path:
     name: Set the path for the EMHASS configuration file
     description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder

--- a/emhass-test/translations/en.yaml
+++ b/emhass-test/translations/en.yaml
@@ -10,7 +10,7 @@ configuration:
     description: long_lived_token (Default "empty").If using the supervisor (this Home Assistant) you can leave this to the default "empty" value.  Otherwise enter the Long-Lived Access Token for your Home Assistant instance, this can be created from the Lovelace profile page.
   data_path:
     name: Set folder path where EMHASS data will be stored
-    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only accessible by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
+    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only accessible by the addon itself. Select /share, /share/emhass or /config to store data in a mounted folder, accessible outside of the addon.
   config_path:
     name: Set the path for the EMHASS configuration file
     description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder

--- a/emhass-test/translations/en.yaml
+++ b/emhass-test/translations/en.yaml
@@ -10,7 +10,10 @@ configuration:
     description: long_lived_token (Default "empty").If using the supervisor (this Home Assistant) you can leave this to the default "empty" value.  Otherwise enter the Long-Lived Access Token for your Home Assistant instance, this can be created from the Lovelace profile page.
   data_path:
     name: Set folder path where EMHASS data will be stored
-    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only assessable by the addon itself. Select /share/emhass to store data in the mounted share folder, accessible outside of the addon.
+    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only assessable by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
+  config_path:
+    name: Set the path for the EMHASS configuration file
+    description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder
   time_zone:
     name: The time zone of your system.
     description: time_zone, (Default Europe/Paris) this is automatically set if your are using the supervisor.

--- a/emhass/config.yml
+++ b/emhass/config.yml
@@ -16,6 +16,9 @@ ports_description:
 webui: http://[HOST]:[PORT:5000]
 map:
   - share:rw
+  - type: addon_config
+    path: /config
+    read_only: False
 init: false
 hassio_role: default
 homeassistant_api: true
@@ -27,7 +30,8 @@ panel_title: EMHASS
 schema:
   hass_url: "str?" #optional
   long_lived_token: "password?" #optional
-  data_path: "list(default|/data/|/share)?" #optional
+  data_path: "list(default|/config|/data|/share|/share/emhass)?" #optional
+  config_path: "list(default|/config/config.json|/share/config.json|/share/emhass/config.json)?" #optional
   time_zone: "match((\\w+)?(\\/)(\\w+))?" #optional
   Latitude: "float?" #optional
   Longitude: "float?" #optional

--- a/emhass/translations/en.yaml
+++ b/emhass/translations/en.yaml
@@ -10,7 +10,7 @@ configuration:
     description: long_lived_token (Default "empty").If using the supervisor (this Home Assistant) you can leave this to the default "empty" value.  Otherwise enter the Long-Lived Access Token for your Home Assistant instance, this can be created from the Lovelace profile page.
   data_path:
     name: Set folder path where EMHASS data will be stored
-    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only assessable by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
+    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only accessible by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
   config_path:
     name: Set the path for the EMHASS configuration file
     description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder

--- a/emhass/translations/en.yaml
+++ b/emhass/translations/en.yaml
@@ -10,7 +10,10 @@ configuration:
     description: long_lived_token (Default "empty").If using the supervisor (this Home Assistant) you can leave this to the default "empty" value.  Otherwise enter the Long-Lived Access Token for your Home Assistant instance, this can be created from the Lovelace profile page.
   data_path:
     name: Set folder path where EMHASS data will be stored
-    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only assessable by the addon itself. Select /share/emhass to store data in the mounted share folder, accessible outside of the addon.
+    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only assessable by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
+  config_path:
+    name: Set the path for the EMHASS configuration file
+    description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder
   time_zone:
     name: The time zone of your system.
     description: time_zone, (Default Europe/Paris) this is automatically set if your are using the supervisor.

--- a/emhass/translations/en.yaml
+++ b/emhass/translations/en.yaml
@@ -10,10 +10,10 @@ configuration:
     description: long_lived_token (Default "empty").If using the supervisor (this Home Assistant) you can leave this to the default "empty" value.  Otherwise enter the Long-Lived Access Token for your Home Assistant instance, this can be created from the Lovelace profile page.
   data_path:
     name: Set folder path where EMHASS data will be stored
-    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only accessible by the addon itself. Select /share, /share/emhass or /config to store data in an mounted folder, accessible outside of the addon.
+    description: data_path (Default default), selecting /data/ will store data in an enclosed folder, only accessible by the addon itself. Select /share, /share/emhass or /config to store data in a mounted folder, accessible outside of the addon.
   config_path:
     name: Set the path for the EMHASS configuration file
-    description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder
+    description: config_path (Default default), selecting default or /config/config.json will store the config file in the Home Assistant addons_configs/ folder.
   time_zone:
     name: The time zone of your system.
     description: time_zone, (Default Europe/Paris) this is automatically set if your are using the supervisor.


### PR DESCRIPTION
make config_path as optional configuration in the addon. #122 

<img width="794" height="252" alt="image" src="https://github.com/user-attachments/assets/5b80ab88-d80a-478b-9d57-e527b3b995ac" />

if nothing or default is selected it will check for config file in folders in following order:

1. /config/config.json
2. /share/config.json

If it find the file in `/config/config.json` it will take this directory directly.
if it find the file in `/share/config.json` it will try to move it to `/config/config.json`
it moving is successful the new folder is used. else, it continue with `/share/config.json`

most users won't recognize this change. for rely on the file in /share. they can now manually opt.

underlying changes to emhass are passed as https://github.com/davidusb-geek/emhass/pull/719


@davidusb-geek I would be happy if you can merge both pull requests. 


furthermore adding `/share/emhass` to data_path config
<img width="992" height="296" alt="image" src="https://github.com/user-attachments/assets/22cb75e8-5c3e-436b-a230-9146760522f1" />

## Summary by Sourcery

Add optional configuration for EMHASS add-ons to control where data and configuration files are stored, including support for Home Assistant addon config directories.

New Features:
- Allow selecting multiple data storage locations including /config, /data, /share, and /share/emhass for EMHASS add-ons.
- Introduce an optional config_path setting to choose the EMHASS configuration file location, with sensible defaults aligned with Home Assistant addon config folders.

Enhancements:
- Mount the addon configuration directory into the EMHASS add-ons to support storing configuration in /config.
- Update English UI copy to describe the new data_path and config_path options for both EMHASS and EMHASS-test add-ons.